### PR TITLE
new: test for github actions that capture is properly made

### DIFF
--- a/tests/testing_github.py
+++ b/tests/testing_github.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import time
 from pylookyloo import Lookyloo
 
 
@@ -13,9 +14,18 @@ class UnitTesting(unittest.TestCase):
     def setUpClass(cls) -> None:
         setattr(cls, "github_instance", Lookyloo('http://127.0.0.1:5100'))
 
-    # Check that lookyloo.circl.lu is up
+    # Check that the local instance (started in github actions of lookyloo) is up
     def test_github_instance_is_up(self) -> None:
         self.assertTrue(self.github_instance.is_up)
+
+    # Check that a capture is properly made
+    def test_capture(self) -> None:
+        # Query a url for capture; save uuid of the capture in a variable
+        uuid = self.github_instance.enqueue('http://lookyloo-testing.herokuapp.com/', True)
+        # Wait 60 seconds for the capture to complete (could be reduced)
+        time.sleep(60)
+        # get_status returns 1 in 'status_code' key if capture is ready
+        self.assertEqual(1, self.github_instance.get_status(uuid)['status_code'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
> time.sleep could be reduced but a capture takes about 45 seconds to be ready, thus making the deployment test on each push pretty slow